### PR TITLE
Configured fuel categories for IR2 heavy roller

### DIFF
--- a/compatibility-scripts/data-final-fixes/IndustrialRevolution.lua
+++ b/compatibility-scripts/data-final-fixes/IndustrialRevolution.lua
@@ -567,8 +567,12 @@ if mods["IndustrialRevolution"] then
   -- Locomotive
   data.raw.locomotive["locomotive"].burner.fuel_categories = { "chemical", "vehicle-fuel", "battery" }
   data.raw.locomotive["locomotive"].burner.fuel_category = nil
+  
+  -- Cars
   data.raw.car["monowheel"].burner.fuel_categories = { "chemical", "vehicle-fuel", "battery" }
   data.raw.car["monowheel"].burner.fuel_category = nil
+  data.raw.car["heavy-roller"].burner.fuel_categories = { "chemical", "vehicle-fuel", "battery" }
+  data.raw.car["heavy-roller"].burner.fuel_category = nil
 
   -----------------------------------------------------------------------------------------------------------------------
   -- -- OTHERS


### PR DESCRIPTION
Currently with K2 + IR2, the heavy roller only accepts K2 vehicle fuels. 
This is weird since the heavy roller is unlocked with the 2nd science pack and the first vehicle fuel is unlocked with the 4th science pack. 

I'm not a veteran factorio mod writer, I hope this is the correct way to fix this.