### PR TITLE
Don't add electric poles in sandbox mode

### DIFF
--- a/scripts/freeplay.lua
+++ b/scripts/freeplay.lua
@@ -16,6 +16,7 @@ end
 
 function freeplay.add_electric_poles()
   if
+    remote.interfaces["freeplay"] and
     (game.active_mods["IndustrialRevolution"] or game.active_mods["aai-industry"])
     and game.item_prototypes["medium-electric-pole"]
   then


### PR DESCRIPTION
Fixes a bug in 1.2.8 when K2+AAI are enabled in Sandbox mode.