### PR TITLE
Ignore tech cost multiplier

### DIFF
--- a/compatibility-scripts/data-final-fixes/aai-industry.lua
+++ b/compatibility-scripts/data-final-fixes/aai-industry.lua
@@ -16,6 +16,24 @@ if mods["aai-industry"] then
   krastorio.technologies.convertPrerequisiteFromAllTechnologies("kr-electric-mining-drill", "electric-mining")
   data.raw.technology["kr-electric-mining-drill"] = nil
 
+  -- AAI Industry makes Greenhouse a dependency of these technologies. Disable cost multiplier to avoid manually harvesting
+  -- unreasonable amounts of wood.
+  local tech_multiplier_everywhere = krastorio.general.getSafeSettingValue("kr-tech-multiplier-everywhere")
+  if not tech_multiplier_everywhere then
+    local tech = data.raw.technology["automation-science-pack"]
+    if tech ~= nil then
+      tech.ignore_tech_cost_multiplier = true
+    end
+    tech = data.raw.technology["fuel-processing"]
+    if tech ~= nil then
+      tech.ignore_tech_cost_multiplier = true
+    end
+    tech = data.raw.technology["electricity"]
+    if tech ~= nil then
+      tech.ignore_tech_cost_multiplier = true
+    end
+  end
+
   -- Fuel prerequisite
   if krastorio.general.getSafeSettingValue("aai-fuel-processor") then
     krastorio.technologies.addPrerequisite("kr-fuel", "fuel-processing")

--- a/locale/en/Krastorio2.cfg
+++ b/locale/en/Krastorio2.cfg
@@ -472,6 +472,7 @@ kr-electric-poles-changes=Improve power poles
 kr-finite-oil=Finite oil
 kr-fix-laser-artillery-turret=Fix laser turret sound glitch.
 kr-impossible-more-than-difficult=Impossible more than difficult [color=red](UNSUPPORTED)[/color]
+kr-tech-multiplier-everywhere=Use tech multiplier for all technologies
 kr-infinite-technology=Infinite technology
 kr-kl-stuff=Include some items from KL
 kr-large-icons=Scale info icons
@@ -510,6 +511,7 @@ kr-electric-poles-changes=Increases the supply area and wire reach distance of e
 kr-finite-oil=Makes oil finite with a constant production rate.
 kr-fix-laser-artillery-turret=This "fix" simply turns off the reload sound for the laser turret, to work around a sound glitch.
 kr-impossible-more-than-difficult=[color=red]THIS MODE IS UNSUPPORTED, DO NOT REPORT BUGS REGARDING IT, THEY WILL NOT BE FIXED.[/color]\nDoubles the cost of ingredients for all recipes and technologies in expensive mode. This is different from the normal expensive mode, because instead of increases the difficulty of [color=orange]focused[/color] recipes and/or technologies, it doubles all recipes, [color=orange]even recipes from other mods[/color]. Should not affect the normal mode, but you have no reason to activate this option if you don't play in expensive mode. (Disabled by default)
+kr-tech-multiplier-everywhere=Use technology cost multiplier for all research. Technologies that depend on manually harvesting resources have problem with scaling, and so they ignore the tech multiplier by default.
 kr-infinite-technology=Enable infinite upgrades for all technologies that increase a property of some in-game item and that have more than five upgrade levels. (Default: enabled)
 kr-kl-stuff=We were often asked to return the old reinforced plates. Well... you can do it with this option.
 kr-large-icons=Increases the size of the icons that display the contents in large chests and warehouses.

--- a/locale/sv-SE/Krastorio2.cfg
+++ b/locale/sv-SE/Krastorio2.cfg
@@ -361,9 +361,11 @@ kr-not-a-patron=Stygga barn får rutten potatis till middag.
 
 [mod-setting-name]
 kr-loaders=Lägg till Krastorio lastare
+kr-tech-multiplier-everywhere=Använd vetenskapliga kostnadsfaktorn överallt
 
 [mod-setting-description]
 kr-loaders=Lägger till lastare. Inaktivera för att använda lastare från andra moddar (dvs miniloaders).
+kr-tech-multiplier-everywhere=Teknologi som beror på att man skördar för hand skalar inte så bra, så dessa ingorerar annars den vetenskapliga kostnadsfaktorn.
 
 [other]
 conservative-additional-inserter-description=__1__ __2__

--- a/prototypes/technologies/only-buildings-unlocking.lua
+++ b/prototypes/technologies/only-buildings-unlocking.lua
@@ -31,6 +31,8 @@ data:extend({
       },
       time = 20,
     },
+     -- Disable cost multiplier to avoid manually harvesting unreasonable amount of wood.
+    ignore_tech_cost_multiplier = not krastorio.general.getSafeSettingValue("kr-tech-multiplier-everywhere"),
   },
   {
     type = "technology",
@@ -141,6 +143,8 @@ data:extend({
       },
       time = 30,
     },
+     -- Disable cost multiplier to avoid manually harvesting unreasonable amount of wood.
+    ignore_tech_cost_multiplier = not krastorio.general.getSafeSettingValue("kr-tech-multiplier-everywhere"),
   },
   -----------------------------------------------------------------------
   -- AUTOMATION TIER AND UPPER

--- a/prototypes/technologies/only-items-unlocking.lua
+++ b/prototypes/technologies/only-items-unlocking.lua
@@ -23,7 +23,8 @@ data:extend({
       },
       time = 20,
     },
-    ignore_tech_cost_multiplier = true,
+     -- Disable cost multiplier to avoid manually harvesting unreasonable amount of wood.
+    ignore_tech_cost_multiplier = not krastorio.general.getSafeSettingValue("kr-tech-multiplier-everywhere"),
   },
   {
     type = "technology",
@@ -94,6 +95,8 @@ data:extend({
       },
       time = 30,
     },
+     -- Disable cost multiplier to avoid manually harvesting unreasonable amount of wood.
+    ignore_tech_cost_multiplier = not krastorio.general.getSafeSettingValue("kr-tech-multiplier-everywhere"),
   },
   ---
   -- Fuels

--- a/prototypes/technologies/uncategorized-technologies.lua
+++ b/prototypes/technologies/uncategorized-technologies.lua
@@ -131,6 +131,8 @@ data:extend({
       },
       time = 45,
     },
+     -- Disable cost multiplier to avoid manually harvesting unreasonable amount of wood.
+    ignore_tech_cost_multiplier = not krastorio.general.getSafeSettingValue("kr-tech-multiplier-everywhere"),
   },
   {
     type = "technology",
@@ -473,6 +475,8 @@ data:extend({
       },
       time = 45,
     },
+     -- Disable cost multiplier to avoid manually harvesting unreasonable amount of Bio matter.
+    ignore_tech_cost_multiplier = not krastorio.general.getSafeSettingValue("kr-tech-multiplier-everywhere"),
   },
   -- Enriched ores, copper and iron
   {

--- a/settings.lua
+++ b/settings.lua
@@ -71,6 +71,13 @@ data:extend({
   },
   {
     type = "bool-setting",
+    name = "kr-tech-multiplier-everywhere",
+    setting_type = "startup",
+    default_value = false,
+    order = "aa",
+  },
+  {
+    type = "bool-setting",
     name = "kr-fix-laser-artillery-turret",
     setting_type = "startup",
     default_value = false,


### PR DESCRIPTION
Some technologies that use manual harvesting have problems scaling with a higher
science factor, and so they should ignore the tech cost multiplier.

Create a settings flag for hardcore mode that will revert to the old
functionality, using science multiplier on all technology.

kr-automation-core already had the ignore flag, but I don't know why. I changed it so that it is possible to override using
the new settings flag.