### PR TITLE
Compatibility scripts for the mod Space Shuttle

### DIFF
--- a/compatibility-scripts/data-final-fixes/nco-SpaceShuttle.lua
+++ b/compatibility-scripts/data-final-fixes/nco-SpaceShuttle.lua
@@ -1,0 +1,39 @@
+-- compatibility for the mod nco-SpaceShuttle
+-- The Space-Shuttle vehicle is near complete clone of the aircraft/cargo-plane just with a different sprite sheet and some magic to allow it in space, therfore this is a similiar extension as present for aircraft/cargo-plane.
+
+if mods["nco-SpaceShuttle"] then
+    -- Utils
+    local function changePlaneGrid(plane_name, new_grid_name)
+        if data.raw["car"][plane_name] then
+            data.raw["car"][plane_name].equipment_grid = new_grid_name
+        end
+    end
+    data:extend(
+        {
+            -----------------------------------------------------------------------------------------------------------------
+            -----------------------------------------------------------------------------------------------------------------
+            -- se-space-shuttle
+            {
+                type = "equipment-grid",
+                name = "kr-space-shuttle-grid",
+                width = 6,
+                height = 6,
+                equipment_categories = {
+                    "universal-equipment",
+                    "vehicle-equipment",
+                    "vehicle-robot-interaction-equipment",
+                    "vehicle-motor",
+                    "aircraft-equipment"
+                }
+            }
+        }
+    )
+    -- Modifing grids
+    changePlaneGrid("se-space-shuttle", "kr-space-shuttle-grid")
+
+    -- Inter/Cross compatibility with Aircraft Realism compatibility
+    if mods["AircraftRealism"] then
+        -- Modifing airborne grids
+        changePlaneGrid("se-space-shuttle-airborne", "kr-space-shuttle-grid")
+    end
+end

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -89,6 +89,7 @@ local scripts_path = "compatibility-scripts/data-final-fixes/"
 require(scripts_path .. "angels")
 require(scripts_path .. "aai-industry")
 require(scripts_path .. "aircraft")
+require(scripts_path .. "nco-SpaceShuttle")
 require(scripts_path .. "AsphaltRoads")
 -- Bobs (multiple scripts)
 require(scripts_path .. "bobs_mod")


### PR DESCRIPTION
### Compatibility scripts for the mod "Space Shuttle"
**Related mod**: Space Shuttle 
**Mod Portal:** https://mods.factorio.com/mod/nco-SpaceShuttle
**Source:** https://github.com/nicolas-lang/Factorio.SpaceShuttle

### Description
The Space-Shuttle vehicle is a near complete clone of the aircraft/cargo-plane just with a different sprite sheet and some magic to allow it in space, therefore this is a similar extension as present for aircraft/cargo-plane.

### Testing
+ I did a one-shot test with SE, Aircraft and nco-SpaceShuttle.

- _I did not test K2 without SE,Aircraft and nco-SpaceShuttle._
- _I did not test aircraft realism as I don't understand what aircraft realism does._