### PR TITLE
Hide hidden fluids from the flare stack

### DIFF
--- a/lib/public/data-stages/fluid-burner-util.lua
+++ b/lib/public/data-stages/fluid-burner-util.lua
@@ -126,7 +126,7 @@ function krastorio.fluid_burner_util.generateBurnFluidsRecipe(fluid_name)
     local tech = krastorio.technologies.getTechnologyThatUnlockRecipe("kr-fluid-burner")
     local tech_name = tech and tech.name or nil
     local accepted = false
-    if not krastorio.fluid_burner_util.blacklist[fluid_name] and not data.raw.fluid[fluid_name].hidden thenHi
+    if not krastorio.fluid_burner_util.blacklist[fluid_name] and not data.raw.fluid[fluid_name].hidden then
       accepted = true
     end -- blacklist
 

--- a/lib/public/data-stages/fluid-burner-util.lua
+++ b/lib/public/data-stages/fluid-burner-util.lua
@@ -126,7 +126,7 @@ function krastorio.fluid_burner_util.generateBurnFluidsRecipe(fluid_name)
     local tech = krastorio.technologies.getTechnologyThatUnlockRecipe("kr-fluid-burner")
     local tech_name = tech and tech.name or nil
     local accepted = false
-    if not krastorio.fluid_burner_util.blacklist[fluid_name] then
+    if not krastorio.fluid_burner_util.blacklist[fluid_name] and not data.raw.fluid[fluid_name].hidden thenHi
       accepted = true
     end -- blacklist
 


### PR DESCRIPTION
doesn't generate flare stack recipes for hidden fluids, [like the ones from LTN](https://github.com/Yousei9/Logistic-Train-Network/blob/75faebf624a4778c009dd9718534c2eb6023bce2/prototypes/signals.lua#L197), and apparently also a question mark fluid from k2?

![Screen Shot 2022-01-10 at 20 46 18](https://user-images.githubusercontent.com/3179271/148831939-58e769b6-4209-4a03-a10f-4ed9a8482177.png)
![Screen Shot 2022-01-10 at 21 05 18](https://user-images.githubusercontent.com/3179271/148831947-60eaafca-12ac-4d7a-84f6-281265c93c78.png)
