### PR TITLE
Leave logistic chests alone if `aai-containers` is present

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.2.18
 Date: ????
+  Compatibility:
+    - [AAI Containers] Updated ordering of logistic chests to match the other containers (#168)
   Bugfixes:
     - Fixed a crash when the tesla coil beam isn't created for some reason
 ---------------------------------------------------------------------------------------------------

--- a/prototypes/vanilla-changes/mandatory/items-sorting.lua
+++ b/prototypes/vanilla-changes/mandatory/items-sorting.lua
@@ -1,17 +1,19 @@
 -- -- -- Sorting changes to vanilla items
 
 -- Logistic chests
-local logistc_subgroup_1 = "kr-logistics-1"
-data.raw.item["logistic-chest-active-provider"].subgroup = logistc_subgroup_1
-data.raw.item["logistic-chest-active-provider"].order = "a[chest-active-provider]"
-data.raw.item["logistic-chest-buffer"].subgroup = logistc_subgroup_1
-data.raw.item["logistic-chest-buffer"].order = "b[chest-buffer]"
-data.raw.item["logistic-chest-passive-provider"].subgroup = logistc_subgroup_1
-data.raw.item["logistic-chest-passive-provider"].order = "c[chest-passive-provider]"
-data.raw.item["logistic-chest-requester"].subgroup = logistc_subgroup_1
-data.raw.item["logistic-chest-requester"].order = "d[chest-requester]"
-data.raw.item["logistic-chest-storage"].subgroup = logistc_subgroup_1
-data.raw.item["logistic-chest-storage"].order = "e[chest-storage]"
+if mods["aai-containers"] then
+  local logistic_subgroup_1 = "kr-logistics-1"
+  data.raw.item["logistic-chest-active-provider"].subgroup = logistic_subgroup_1
+  data.raw.item["logistic-chest-active-provider"].order = "a[chest-active-provider]"
+  data.raw.item["logistic-chest-buffer"].subgroup = logistic_subgroup_1
+  data.raw.item["logistic-chest-buffer"].order = "b[chest-buffer]"
+  data.raw.item["logistic-chest-passive-provider"].subgroup = logistic_subgroup_1
+  data.raw.item["logistic-chest-passive-provider"].order = "c[chest-passive-provider]"
+  data.raw.item["logistic-chest-requester"].subgroup = logistic_subgroup_1
+  data.raw.item["logistic-chest-requester"].order = "d[chest-requester]"
+  data.raw.item["logistic-chest-storage"].subgroup = logistic_subgroup_1
+  data.raw.item["logistic-chest-storage"].order = "e[chest-storage]"
+end
 
 -- Radar and rocket silo
 data.raw.item["radar"].subgroup = "radars-and-rockets"

--- a/prototypes/vanilla-changes/mandatory/items-sorting.lua
+++ b/prototypes/vanilla-changes/mandatory/items-sorting.lua
@@ -1,7 +1,7 @@
 -- -- -- Sorting changes to vanilla items
 
 -- Logistic chests
-if mods["aai-containers"] then
+if not mods["aai-containers"] then
   local logistic_subgroup_1 = "kr-logistics-1"
   data.raw.item["logistic-chest-active-provider"].subgroup = logistic_subgroup_1
   data.raw.item["logistic-chest-active-provider"].order = "a[chest-active-provider]"


### PR DESCRIPTION
When you use AAI Containers together with Krastorio 2 there are discrepancies between the color order as well as wood and iron being weirdly placed, this pull request aims to fix that by letting `aai-containers` take charge in ordering them.

I am a bit torn between options on how to fix this:
1) disabling the krastorio 2 override if aai containers is present in items-sorting.lua (this pull)
2) putting the opposite of the change in compatibility-scripts, but then you'd have to hardcode the "original" or "aai" values
3) triggering that if inside vanilla changes from within compatibility scripts somehow, or make it a setting?
4) potentially having to move it to optional changes for the sake of naming?
5) a limbo compatibility mod that requires aai industry, saves the data stage, and then restore that in final fixes by overriding krastorio?

option 1 simply seemed like the least horrible/cluttered solution, i would love to hear your thought tho 🤔 

How it is currently:
![Screen Shot 2022-01-19 at 21 02 50](https://user-images.githubusercontent.com/3179271/150205706-16d5ae53-e4d9-4b01-b2d6-06139e6826a3.png)

What this pull request will do:
![Screen Shot 2022-01-19 at 21 01 28](https://user-images.githubusercontent.com/3179271/150205785-7fe6aefc-83d0-49f5-becd-15f2a5fd7eb6.png)

(also took the liberty of correcting the `logistc` typo in the local variable)

edit 1:

6) moving the code from vanilla-fixes to compatibility-scripts and trigger it when the mod is false? (a bit backwardsy)