### PR TITLE
Handle transciever remote calls from mods loaded before K2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ Date: ????
     - Added auto-generated recipes for modded trees and rocks in the greenhouse (#115)
     - [Space Exploration] Added landfill recipes made from raw imersite and raw rare metals (#115)
     - [Space Exploration] The Deep Space Loader will match the belt color of the deep space belt it is connected to (#115)
+    - Fixed intergalactic transceiver not respecting "no victory" remote calls from mods loaded before K2.
   Bugfixes:
     - Fixed inaccurate max consumption for the energy absorber (#249)
     - Fixed that all entities would be radioactive if no radioactive entities were defined (#256)

--- a/scripts/intergalactic-transceiver.lua
+++ b/scripts/intergalactic-transceiver.lua
@@ -13,12 +13,14 @@ local statuses = constants.intergalactic_transceiver.statuses
 local cutscene_const = constants.intergalactic_transceiver.cutscene
 
 function intergalactic_transceiver.init()
-  global.intergalactic_transceiver = {
-    forces = {},
-    guis = {},
-    inactive = {},
-    is_victory = true,
-  }
+  if not global.intergalactic_transceiver then -- Can be already initialised through remote interface
+    global.intergalactic_transceiver = {
+      forces = {},
+      guis = {},
+      inactive = {},
+      is_victory = true,
+    }
+  end
 end
 
 function intergalactic_transceiver.get_max_energy()
@@ -511,17 +513,15 @@ intergalactic_transceiver.gui_actions = actions
 
 intergalactic_transceiver.remote_interface = {
   get_no_victory = function()
-    if global.intergalactic_transceiver then
-      return not global.intergalactic_transceiver.is_victory
-    end
+    if not global.intergalactic_transceiver then intergalactic_transceiver.init() end
+    return not global.intergalactic_transceiver.is_victory
   end,
   set_no_victory = function(to_state)
     if not to_state or type(to_state) ~= "boolean" then
       error("`to_state` must be a boolean")
     end
-    if global.intergalactic_transceiver then
-      global.intergalactic_transceiver.is_victory = not to_state
-    end
+    if not global.intergalactic_transceiver then intergalactic_transceiver.init() end
+    global.intergalactic_transceiver.is_victory = not to_state
   end,
 }
 


### PR DESCRIPTION
This is actually affecting SE. We used to do the `set_no_victory` call in SE-postprocess which always runs last, but in December we moved it back to the main mod. Unfortunately `space-exploration` runs before `Krastorio2`. No one noticed because it didn't affect existing games, and it takes a long time for a new game to get to this point.