### PR TITLE
Bugfixing and more for recipes.lua in K2s compatability scritps

### DIFF
--- a/compatibility-scripts/data-final-fixes/space-exploration/0.3.X/recipes.lua
+++ b/compatibility-scripts/data-final-fixes/space-exploration/0.3.X/recipes.lua
@@ -70,8 +70,6 @@ if mods["space-exploration"] and krastorio.general.isVersionGreaterEqualThan(mod
     krastorio.technologies.removeUnlockRecipeFromAllTechnologies("glass-from-sand")
     krastorio.modules.removeProductivityLimitation("glass-from-sand")
   end
-  -- Boost SE glass recipe
-  krastorio.recipes.replaceProduct("se-glass-vulcanite", "glass", { "glass", 16 })
 
   -- Move lithium sulfur battery
   data.raw["recipe"]["lithium-sulfur-battery"].subgroup = "intermediate-product"

--- a/compatibility-scripts/data-final-fixes/space-exploration/0.3.X/recipes.lua
+++ b/compatibility-scripts/data-final-fixes/space-exploration/0.3.X/recipes.lua
@@ -9,9 +9,6 @@ if mods["space-exploration"] and krastorio.general.isVersionGreaterEqualThan(mod
   krastorio.modules.removeProductivityLimitation("se-rocket-fuel-from-water-copper")
   krastorio.recipes.setCategoryIfExist("rocket-fuel", "fuel-refinery")
 
-  -- Restore the satellite production from sending satellite in the space to get K2 space data
-  data.raw.item["satellite"].rocket_launch_product = { "space-research-data", 1000 }
-
   -- Change the core fragments value to rebalance well the gain value
   local function scaleCoreFragmentRecipe(_recipe_name, _item_name, _multiplier)
     local cf_recipe_name = "se-core-fragment-" .. _recipe_name

--- a/compatibility-scripts/data-final-fixes/space-exploration/0.3.X/recipes.lua
+++ b/compatibility-scripts/data-final-fixes/space-exploration/0.3.X/recipes.lua
@@ -9,34 +9,6 @@ if mods["space-exploration"] and krastorio.general.isVersionGreaterEqualThan(mod
   krastorio.modules.removeProductivityLimitation("se-rocket-fuel-from-water-copper")
   krastorio.recipes.setCategoryIfExist("rocket-fuel", "fuel-refinery")
 
-  -- Change the core fragments value to rebalance well the gain value
-  local function scaleCoreFragmentRecipe(_recipe_name, _item_name, _multiplier)
-    local cf_recipe_name = "se-core-fragment-" .. _recipe_name
-    local amount = krastorio.recipes.countProduct("se-core-fragment-omni", _item_name)
-    local _item_type = krastorio.items.getItemType(_item_name)
-    krastorio.recipes.replaceProduct(
-      "se-core-fragment-omni",
-      _item_name,
-      { type = _item_type, name = _item_name, amount = amount * _multiplier }
-    )
-    krastorio.recipes.replaceProduct(
-      cf_recipe_name,
-      _item_name,
-      { type = _item_type, name = _item_name, amount = amount * _multiplier }
-    )
-  end
-
-  local core_fragment_to_change = {
-    ["imersite"] = { "raw-imersite", 0.2 },
-    ["rare-metals"] = { "raw-rare-metals", 0.2 },
-    ["mineral-water"] = { "mineral-water", 0.25 },
-    ["crude-oil"] = { "crude-oil", 0.5 },
-  }
-
-  for item_name, multiplier in pairs(core_fragment_to_change) do
-    scaleCoreFragmentRecipe(item_name, multiplier[1], multiplier[2])
-  end
-
   -- Adding new K2 recipe categories to some space machines to make users able to process the K2 intermediates in the space
   krastorio.entities.addCraftingCategory("assembling-machine", "se-space-mechanical-laboratory", "crushing")
   krastorio.entities.addCraftingCategory("assembling-machine", "se-pulveriser", "crushing")

--- a/compatibility-scripts/data-final-fixes/space-exploration/0.3.X/recipes.lua
+++ b/compatibility-scripts/data-final-fixes/space-exploration/0.3.X/recipes.lua
@@ -43,7 +43,6 @@ if mods["space-exploration"] and krastorio.general.isVersionGreaterEqualThan(mod
   -- Adding new K2 recipe categories to some space machines to make users able to process the K2 intermediates in the space
   krastorio.entities.addCraftingCategory("assembling-machine", "se-space-mechanical-laboratory", "crushing")
   krastorio.entities.addCraftingCategory("assembling-machine", "se-pulveriser", "crushing")
-  krastorio.entities.addCraftingCategory("assembling-machine", "se-space-biochemical-laboratory", "electrolysis")
   krastorio.entities.addCraftingCategory("assembling-machine", "se-space-decontamination-facility", "fluid-filtration")
 
   -- Merge the sand recipes

--- a/compatibility-scripts/data-final-fixes/space-exploration/0.3.X/recipes.lua
+++ b/compatibility-scripts/data-final-fixes/space-exploration/0.3.X/recipes.lua
@@ -77,26 +77,26 @@ if mods["space-exploration"] and krastorio.general.isVersionGreaterEqualThan(mod
   data.raw["recipe"]["lithium-sulfur-battery"].subgroup = "intermediate-product"
 
   -- Add additional landfill recipes
-  local template = data.raw["recipe"]["landfill-iron-ore"]
-  local tech = data.raw["technology"]["se-recycling-facility"]
+  local template = data.raw.recipe["landfill-iron-ore"]
+  local tech = data.raw.technology["se-recycling-facility"]
   for _, resource_name in pairs({ "raw-rare-metals", "raw-imersite" }) do
     local recipe = table.deepcopy(template)
     recipe.name = "landfill-" .. resource_name
-    recipe.result = resource_name
-    -- FIXME: THIS IS AWFUL. DO NOT RELEASE LIKE THIS. BAD BAD BAD. VERY BAD.
-    -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    recipe.order = "z-b-" .. resource_name
+    recipe.icon = nil
     recipe.icons = {
-      { icon = "__base__/graphics/icons/landfill.png", icon_size = 64 },
-      {
-        icon = data.raw["item"][resource_name].icon,
-        icon_size = 64,
-        scale = 0.26,
-        shift = { 8, -8 },
-      },
+      { icon = data.raw.item["landfill"].icon , icon_size = data.raw.item["landfill"].icon_size},
+      { icon = data.raw.item[resource_name].icon, icon_size = data.raw.item[resource_name].icon_size, scale = 0.33},
     }
-    recipe.normal.ingredients = { { resource_name, 50 } }
-    recipe.expensive.ingredients = { { resource_name, 50 } }
-    log(serpent.block(recipe))
+    if recipe.ingredients then
+      recipe.ingredients = {{name = resource_name, amount = 50}}
+    end
+    if recipe.normal and recipe.normal.ingredients then
+      recipe.normal.ingredients = {{name = resource_name, amount = 50}}
+    end
+    if recipe.expensive and recipe.expensive.ingredients then
+      recipe.expensive.ingredients = {{name = resource_name, amount = 50}}
+    end
     table.insert(tech.effects, { type = "unlock-recipe", recipe = recipe.name })
     data:extend({ recipe })
   end


### PR DESCRIPTION
Basically, I'm going through and making some changes that tie in with changes I'm making to the SE side of things. This pull request changes it so that:

- SE Postprocess takes ownership of the Core Fragment resource amounts, previously both mods tried to make the same changes with SE Postprocess' changes taking precedence due to mod load order.
- SE takes ownership of the Glass-Vulcanite recipe as the new resource progression means we now provide more glass per sand than the amount given here.
- K2 added the electrolysis crafting category to the biochemical facility, SE Postprocess removes it as part of the Solid Rocket Fuel rebalance, so now it's addition is removed and so the removal can be removed in SE Postprocess.
- SE overwrites the rocket launch product for the satellite for it's Rocket Science Pack, and the actual item space-research-data is modified by SE Postprocess to be crafted instead.
- The Landfill recipes for Imersite and Rare Metals are brought in line with the definitions from SE, so I hope that that is alright and the "FIXME" removal is fine :)