### PR TITLE
Add fluidboxes to the Research and Advanced Research servers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,8 @@ Date: ????
   Compatibility:
     - Added auto-generated recipes for modded trees and rocks in the greenhouse (#115)
     - Added fluidbox connections to the advanced furnace (#278)
+    - Added fluidbox connections to the research server
+    - Added fluidbox connections to the advanced research server
     - Fixed intergalactic transceiver not respecting "no victory" remote calls from mods loaded before K2.
     - [Realistic Reactors] Heat exchangers output 10 MW (#282)
     - [Space Exploration] Added landfill recipes made from raw imersite and raw rare metals (#115)

--- a/compatibility-scripts/data-final-fixes/space-exploration/0.3.X/entities.lua
+++ b/compatibility-scripts/data-final-fixes/space-exploration/0.3.X/entities.lua
@@ -22,7 +22,6 @@ if mods["space-exploration"] and krastorio.general.isVersionGreaterEqualThan(mod
   -- Fix laboratory science packs
   if data.raw.lab["kr-singularity-lab"] then
     table.insert(data.raw.lab["kr-singularity-lab"].inputs, "space-science-pack")
-    table.insert(data.raw.lab["kr-singularity-lab"].inputs, "se-deep-space-science-pack")
   end
 
   -- Rebalance the electric boiler to not create infinite energy

--- a/compatibility-scripts/data-final-fixes/space-exploration/0.3.X/entities.lua
+++ b/compatibility-scripts/data-final-fixes/space-exploration/0.3.X/entities.lua
@@ -116,5 +116,4 @@ if mods["space-exploration"] and krastorio.general.isVersionGreaterEqualThan(mod
   -- -- Singularity laboratory fixes
   -- Special collision
   data.raw["lab"]["kr-singularity-lab"].collision_mask = data.raw["lab"]["se-space-science-lab"].collision_mask
-  krastorio.entities.addLabInput("kr-singularity-lab", "se-deep-space-science-pack")
 end

--- a/prototypes/entities/buildings/quantum-computer.lua
+++ b/prototypes/entities/buildings/quantum-computer.lua
@@ -1,6 +1,71 @@
 local hit_effects = require("__base__/prototypes/entity/hit-effects")
 local sounds = require("__base__/prototypes/entity/sounds")
 
+function qunatumkpipepictures()
+  return {
+    north = {
+      filename = kr_entities_path .. "quantum-computer/quantum-computer-k-pipe-N.png",
+      priority = "extra-high",
+      width = 39, --35
+      height = 36, -- 18
+      shift = util.by_pixel(4.25, 23),
+      hr_version = {
+        filename = kr_entities_path .. "quantum-computer/hr-quantum-computer-k-pipe-N.png",
+        priority = "extra-high",
+        width = 78, --71
+        height = 71, -- 38
+        shift = util.by_pixel(4.25, 23),
+        scale = 0.5,
+      },
+    },
+    east = {
+      filename = kr_entities_path .. "quantum-computer/quantum-computer-k-pipe-E.png",
+      priority = "extra-high",
+      width = 20,
+      height = 38,
+      shift = util.by_pixel(-25, 1),
+      hr_version = {
+        filename = kr_entities_path .. "quantum-computer/hr-quantum-computer-k-pipe-E.png",
+        priority = "extra-high",
+        width = 42,
+        height = 76,
+        shift = util.by_pixel(-24.5, 1),
+        scale = 0.5,
+      },
+    },
+    south = {
+      filename = kr_entities_path .. "quantum-computer/quantum-computer-k-pipe-S.png",
+      priority = "extra-high",
+      width = 44,
+      height = 31,
+      shift = util.by_pixel(0, -31.5),
+      hr_version = {
+        filename = kr_entities_path .. "quantum-computer/hr-quantum-computer-k-pipe-S.png",
+        priority = "extra-high",
+        width = 88,
+        height = 61,
+        shift = util.by_pixel(0, -31.25),
+        scale = 0.5,
+      },
+    },
+    west = {
+      filename = kr_entities_path .. "quantum-computer/quantum-computer-k-pipe-W.png",
+      priority = "extra-high",
+      width = 19,
+      height = 37,
+      shift = util.by_pixel(25.5, 1.5),
+      hr_version = {
+        filename = kr_entities_path .. "quantum-computer/hr-quantum-computer-k-pipe-W.png",
+        priority = "extra-high",
+        width = 39,
+        height = 73,
+        shift = util.by_pixel(25.75, 1.25),
+        scale = 0.5,
+      },
+    },
+  }
+end
+
 data:extend({
   {
     type = "assembling-machine",
@@ -21,6 +86,27 @@ data:extend({
     },
     collision_box = { { -2.8, -2.8 }, { 2.8, 2.8 } },
     selection_box = { { -2.95, -2.95 }, { 2.95, 2.95 } },
+    fluid_boxes = {
+      {
+        production_type = "input",
+        pipe_picture = qunatumkpipepictures(),
+        pipe_covers = pipecoverspictures(),
+        base_area = 10,
+        base_level = -1,
+        pipe_connections = { { type = "input", position = { -0.5, -3.5 } } },
+        secondary_draw_orders = { north = -1 },
+      },
+      {
+        production_type = "output",
+        pipe_picture = qunatumkpipepictures(),
+        pipe_covers = pipecoverspictures(),
+        base_area = 10,
+        base_level = 1,
+        pipe_connections = { { type = "output", position = { 0.5, 3.5 } } },
+        secondary_draw_orders = { north = -1 },
+      },
+      off_when_no_fluid_recipe = true,
+    },
     fast_replaceable_group = "assembling-machine",
     animation = {
       layers = {

--- a/prototypes/entities/buildings/research-server.lua
+++ b/prototypes/entities/buildings/research-server.lua
@@ -1,6 +1,71 @@
 local hit_effects = require("__base__/prototypes/entity/hit-effects")
 local sounds = require("__base__/prototypes/entity/sounds")
 
+function serverkpipepictures()
+  return {
+    north = {
+      filename = kr_entities_path .. "research-server/research-server-k-pipe-N.png",
+      priority = "extra-high",
+      width = 35,
+      height = 18,
+      shift = util.by_pixel(2.5, 14),
+      hr_version = {
+        filename = kr_entities_path .. "research-server/hr-research-server-k-pipe-N.png",
+        priority = "extra-high",
+        width = 71,
+        height = 38,
+        shift = util.by_pixel(2.25, 13.5),
+        scale = 0.5,
+      },
+    },
+    east = {
+      filename = kr_entities_path .. "research-server/research-server-k-pipe-E.png",
+      priority = "extra-high",
+      width = 20,
+      height = 38,
+      shift = util.by_pixel(-25, 1),
+      hr_version = {
+        filename = kr_entities_path .. "research-server/hr-research-server-k-pipe-E.png",
+        priority = "extra-high",
+        width = 42,
+        height = 76,
+        shift = util.by_pixel(-24.5, 1),
+        scale = 0.5,
+      },
+    },
+    south = {
+      filename = kr_entities_path .. "research-server/research-server-k-pipe-S.png",
+      priority = "extra-high",
+      width = 44,
+      height = 31,
+      shift = util.by_pixel(0, -31.5),
+      hr_version = {
+        filename = kr_entities_path .. "research-server/hr-research-server-k-pipe-S.png",
+        priority = "extra-high",
+        width = 88,
+        height = 61,
+        shift = util.by_pixel(0, -31.25),
+        scale = 0.5,
+      },
+    },
+    west = {
+      filename = kr_entities_path .. "research-server/research-server-k-pipe-W.png",
+      priority = "extra-high",
+      width = 19,
+      height = 37,
+      shift = util.by_pixel(25.5, 1.5),
+      hr_version = {
+        filename = kr_entities_path .. "research-server/hr-research-server-k-pipe-W.png",
+        priority = "extra-high",
+        width = 39,
+        height = 73,
+        shift = util.by_pixel(25.75, 1.25),
+        scale = 0.5,
+      },
+    },
+  }
+end
+
 data:extend({
   {
     type = "assembling-machine",
@@ -19,6 +84,27 @@ data:extend({
     },
     collision_box = { { -1.25, -1.25 }, { 1.25, 1.25 } },
     selection_box = { { -1.4, -1.4 }, { 1.4, 1.4 } },
+    fluid_boxes = {
+      {
+        production_type = "input",
+        pipe_picture = serverkpipepictures(),
+        pipe_covers = pipecoverspictures(),
+        base_area = 10,
+        base_level = -1,
+        pipe_connections = { { type = "input", position = { 0, -2 } } },
+        secondary_draw_orders = { north = -1 },
+      },
+      {
+        production_type = "output",
+        pipe_picture = serverkpipepictures(),
+        pipe_covers = pipecoverspictures(),
+        base_area = 10,
+        base_level = 1,
+        pipe_connections = { { type = "output", position = { 0, 2 } } },
+        secondary_draw_orders = { north = -1 },
+      },
+      off_when_no_fluid_recipe = true,
+    },
     animation = {
       layers = {
         {


### PR DESCRIPTION
Adding the code to allow for fluid recipes in the Research Server and Advanced Research Server. Primarily for my work on the SE compatibility, but also for any other purpose K2 might need them for :)

Graphics are once again in the following Pull Request: https://github.com/raiguard/krastorio-2-assets/pull/3