### PR TITLE
Support "Spidertron tiers Fix SEK2"

### DIFF
--- a/compatibility-scripts/data-final-fixes/spidertron-tiers.lua
+++ b/compatibility-scripts/data-final-fixes/spidertron-tiers.lua
@@ -13,7 +13,7 @@ local spiders = {
   "voyage_spidertron_mk2",
 }
 
-if mods["spidertrontiers"] then
+if mods["spidertrontiers"] or mods["spidertrontiers-circulardependency"] then
   for _, name in pairs(spiders) do
     local spider = data.raw["spider-vehicle"][name]
     if spider then


### PR DESCRIPTION
https://mods.factorio.com/mod/spidertrontiers-circulardependency

The original Spidertron Tier still has the SE+K2 circular dependency issue after a year, so it looks like this bootleg fix version is here to stay.