### PR TITLE
Do not flip linked belts when the LinkedBelts mod is active, as it se…

### DIFF
--- a/compatibility-scripts/data-updates/LinkedBelts.lua
+++ b/compatibility-scripts/data-updates/LinkedBelts.lua
@@ -1,0 +1,3 @@
+if mods["LinkedBelts"] then
+    krastorio.do_not_flip_linked_belts = true;
+end

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -39,6 +39,7 @@ require(scripts_path .. "Pyanodon")
 -- Schall Uranium Processing
 require(scripts_path .. "SchallUranium")
 require(scripts_path .. "Tral-robot-tree-farm")
+require(scripts_path .. "LinkedBelts")
 ---------------------------------------------------------------------------
 -- -- -- OTHER
 ---------------------------------------------------------------------------

--- a/scripts/loader-snapping.lua
+++ b/scripts/loader-snapping.lua
@@ -80,7 +80,7 @@ function loader_snapping.snap_belt_neighbours(entity)
         end
       end
     end
-    if entity.type == "linked-belt" then
+    if entity.type == "linked-belt" and not krastorio.do_not_flip_linked_belts then
       -- Trying to "flip" the linked belt when it is connected throws an exception
       if entity.linked_belt_neighbour then
         break


### PR DESCRIPTION
…ts input/output mode itself.

As the commit message says,
  LinkedBelts in control.lua sets input/output on the linked belts objects, flipping them here causes them to face opposite of what the user intended and also breaks upgrading, so do not flip them when the LinkedBelts mod is active.